### PR TITLE
fix build with updated ros container, clangd fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,7 +55,7 @@ repos:
         files: \.(yml|yaml)$
 
   - repo: https://github.com/tcort/markdown-link-check
-    rev: v3.12.2
+    rev: v3.13.6
     hooks:
       - id: markdown-link-check
         args:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,9 +58,6 @@ repos:
     rev: v3.13.6
     hooks:
       - id: markdown-link-check
-        args:
-          - "-c"
-          - "markdown-link-check-config.json"
 
   - repo: https://github.com/cheshirekow/cmake-format-precommit
     rev: v0.6.10

--- a/fuse_core/include/fuse_core/callback_wrapper.hpp
+++ b/fuse_core/include/fuse_core/callback_wrapper.hpp
@@ -99,6 +99,11 @@ namespace fuse_core
 class CallbackWrapperBase
 {
 public:
+  virtual ~CallbackWrapperBase() = default;
+  CallbackWrapperBase(CallbackWrapperBase const&) = default;
+  CallbackWrapperBase(CallbackWrapperBase&&) = default;
+  CallbackWrapperBase& operator=(CallbackWrapperBase const&) = default;
+  CallbackWrapperBase& operator=(CallbackWrapperBase&&) = default;
   /**
    * @brief Call this function. This is used by the callback queue.
    */
@@ -109,7 +114,12 @@ template <typename T>
 class CallbackWrapper : public CallbackWrapperBase
 {
 public:
+  virtual ~CallbackWrapper() = default;
   using CallbackFunction = std::function<T(void)>;
+  CallbackWrapper(CallbackWrapper const&) = default;
+  CallbackWrapper(CallbackWrapper&&) = default;
+  CallbackWrapper& operator=(CallbackWrapper const&) = default;
+  CallbackWrapper& operator=(CallbackWrapper&&) = default;
 
   /**
    * @brief Constructor
@@ -153,7 +163,7 @@ inline void CallbackWrapper<void>::call()
 class CallbackAdapter : public rclcpp::Waitable
 {
 public:
-  explicit CallbackAdapter(std::shared_ptr<rclcpp::Context> context_ptr);
+  explicit CallbackAdapter(std::shared_ptr<rclcpp::Context> const& context_ptr);
 
   /**
    * @brief tell the CallbackGroup how many guard conditions are ready in this waitable
@@ -182,6 +192,17 @@ public:
   void addCallback(std::shared_ptr<CallbackWrapperBase>&& callback);
 
   void removeAllCallbacks();
+
+  void set_on_ready_callback(std::function<void(size_t, int)> /*callback*/) override
+  {
+  }
+  void clear_on_ready_callback() override
+  {
+  }
+  std::shared_ptr<void> take_data_by_entity_id(size_t /*id*/) override
+  {
+    return nullptr;
+  }
 
 private:
   rcl_guard_condition_t gc_;  //!< guard condition to drive the waitable

--- a/fuse_core/include/fuse_core/callback_wrapper.hpp
+++ b/fuse_core/include/fuse_core/callback_wrapper.hpp
@@ -100,6 +100,7 @@ class CallbackWrapperBase
 {
 public:
   virtual ~CallbackWrapperBase() = default;
+  CallbackWrapperBase() = default;
   CallbackWrapperBase(CallbackWrapperBase const&) = default;
   CallbackWrapperBase(CallbackWrapperBase&&) = default;
   CallbackWrapperBase& operator=(CallbackWrapperBase const&) = default;
@@ -114,12 +115,7 @@ template <typename T>
 class CallbackWrapper : public CallbackWrapperBase
 {
 public:
-  virtual ~CallbackWrapper() = default;
   using CallbackFunction = std::function<T(void)>;
-  CallbackWrapper(CallbackWrapper const&) = default;
-  CallbackWrapper(CallbackWrapper&&) = default;
-  CallbackWrapper& operator=(CallbackWrapper const&) = default;
-  CallbackWrapper& operator=(CallbackWrapper&&) = default;
 
   /**
    * @brief Constructor

--- a/fuse_core/src/callback_wrapper.cpp
+++ b/fuse_core/src/callback_wrapper.cpp
@@ -37,12 +37,12 @@
 namespace fuse_core
 {
 
-CallbackAdapter::CallbackAdapter(std::shared_ptr<rclcpp::Context> context_ptr)
+CallbackAdapter::CallbackAdapter(std::shared_ptr<rclcpp::Context> const& context_ptr)
+  : gc_(rcl_get_zero_initialized_guard_condition())
 {
   rcl_guard_condition_options_t guard_condition_options = rcl_guard_condition_get_default_options();
 
   // Guard condition is used by the wait set to handle execute-or-not logic
-  gc_ = rcl_get_zero_initialized_guard_condition();
   if (RCL_RET_OK != rcl_guard_condition_init(&gc_, context_ptr->get_rcl_context().get(), guard_condition_options))
   {
     throw std::runtime_error("Could not init guard condition for callback waitable.");

--- a/fuse_core/src/callback_wrapper.cpp
+++ b/fuse_core/src/callback_wrapper.cpp
@@ -40,7 +40,7 @@ namespace fuse_core
 CallbackAdapter::CallbackAdapter(std::shared_ptr<rclcpp::Context> const& context_ptr)
   : gc_(rcl_get_zero_initialized_guard_condition())
 {
-  rcl_guard_condition_options_t guard_condition_options = rcl_guard_condition_get_default_options();
+  rcl_guard_condition_options_t const guard_condition_options = rcl_guard_condition_get_default_options();
 
   // Guard condition is used by the wait set to handle execute-or-not logic
   if (RCL_RET_OK != rcl_guard_condition_init(&gc_, context_ptr->get_rcl_context().get(), guard_condition_options))
@@ -74,7 +74,7 @@ bool CallbackAdapter::is_ready(rcl_wait_set_t const& wait_set)
    */
 void CallbackAdapter::add_to_wait_set(rcl_wait_set_t& wait_set)
 {
-  if (RCL_RET_OK != rcl_wait_set_add_guard_condition(&wait_set, &gc_, NULL))
+  if (RCL_RET_OK != rcl_wait_set_add_guard_condition(&wait_set, &gc_, nullptr))
   {
     RCLCPP_WARN(rclcpp::get_logger("fuse"), "Could not add callback waitable to wait set.");
   }
@@ -89,7 +89,7 @@ std::shared_ptr<void> CallbackAdapter::take_data()
   std::shared_ptr<CallbackWrapperBase> cb_wrapper = nullptr;
   // fetch the callback ptr and release the lock without spending time in the callback
   {
-    std::lock_guard<std::mutex> lock(queue_mutex_);
+    std::lock_guard<std::mutex> const lock(queue_mutex_);
     if (!callback_queue_.empty())
     {
       cb_wrapper = callback_queue_.front();
@@ -122,7 +122,7 @@ void CallbackAdapter::execute(std::shared_ptr<void> const& data)
 
 void CallbackAdapter::addCallback(const std::shared_ptr<CallbackWrapperBase>& callback)
 {
-  std::lock_guard<std::mutex> lock(queue_mutex_);
+  std::lock_guard<std::mutex> const lock(queue_mutex_);
   callback_queue_.push_back(callback);
   if (RCL_RET_OK != rcl_trigger_guard_condition(&gc_))
   {
@@ -134,7 +134,7 @@ void CallbackAdapter::addCallback(const std::shared_ptr<CallbackWrapperBase>& ca
 
 void CallbackAdapter::addCallback(std::shared_ptr<CallbackWrapperBase>&& callback)
 {
-  std::lock_guard<std::mutex> lock(queue_mutex_);
+  std::lock_guard<std::mutex> const lock(queue_mutex_);
   callback_queue_.push_back(std::move(callback));
   if (RCL_RET_OK != rcl_trigger_guard_condition(&gc_))
   {
@@ -146,7 +146,7 @@ void CallbackAdapter::addCallback(std::shared_ptr<CallbackWrapperBase>&& callbac
 
 void CallbackAdapter::removeAllCallbacks()
 {
-  std::lock_guard<std::mutex> lock(queue_mutex_);
+  std::lock_guard<std::mutex> const lock(queue_mutex_);
   callback_queue_.clear();
 }
 


### PR DESCRIPTION
[This PR](https://github.com/ros2/rclcpp/pull/2467) was synced to the ROS docker image, causing build to fail (as seen [here](https://github.com/locusrobotics/fuse/pull/379) too). This fixes that and some clang tidy issues and updates the markdown link checker to remove the pre-commit warning fixed [here](https://github.com/tcort/markdown-link-check/pull/366).