### PR TITLE
Bump covariance geometry ros submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/henrygerardmoore/tf2_2d.git
 [submodule "dependencies/covariance_geometry_ros"]
 	path = dependencies/covariance_geometry_ros
-	url = https://github.com/giafranchini/covariance_geometry_ros.git
+	url = https://github.com/PickNikRobotics/covariance_geometry_ros.git


### PR DESCRIPTION
* Fix submodule CMake to be able to build with debug & ninja mixins

Without this change my build fails if I try colcon build --mixin debug ninja

To test: make sure everything builds successfully with colcon build --mixin release ninja and colcon build --mixin debug ninja