### PR TITLE
Bump version to 1.3.0

### DIFF
--- a/fuse/package.xml
+++ b/fuse/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>fuse</name>
-  <version>1.1.5</version>
+  <version>1.3.0</version>
   <description>
     The fuse metapackage.
   </description>

--- a/fuse_constraints/package.xml
+++ b/fuse_constraints/package.xml
@@ -4,7 +4,7 @@
   schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>fuse_constraints</name>
-  <version>1.1.5</version>
+  <version>1.3.0</version>
   <description>
     The fuse_constraints package provides a set of commonly used constraint types, such as direct measurements on \
     state variables (absolute constraints) or measurements of the state changes (relative constraints).

--- a/fuse_core/package.xml
+++ b/fuse_core/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>fuse_core</name>
-  <version>1.1.5</version>
+  <version>1.3.0</version>
   <description>
     The fuse_core package provides the base class interfaces for the various fuse components. Concrete implementations of these
     interfaces are provided in other packages.

--- a/fuse_doc/package.xml
+++ b/fuse_doc/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>fuse_doc</name>
-  <version>1.1.5</version>
+  <version>1.3.0</version>
   <description>
     The fuse_doc package provides documentation and examples for the fuse package.
   </description>

--- a/fuse_graphs/package.xml
+++ b/fuse_graphs/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>fuse_graphs</name>
-  <version>1.1.5</version>
+  <version>1.3.0</version>
   <description>
     The fuse_graphs package provides some concrete implementations of the fuse_core::Graph interface.
   </description>

--- a/fuse_loss/package.xml
+++ b/fuse_loss/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>fuse_loss</name>
-  <version>1.1.5</version>
+  <version>1.3.0</version>
   <description>
     The fuse_loss package provides a set of commonly used loss functions, such as the basic ones provided by Ceres.
   </description>

--- a/fuse_models/package.xml
+++ b/fuse_models/package.xml
@@ -4,7 +4,7 @@
   schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>fuse_models</name>
-  <version>1.1.5</version>
+  <version>1.3.0</version>
   <description>fuse plugins that implement various kinematic and sensor models</description>
 
   <maintainer email="tmoore@locusrobotics.com">Tom Moore</maintainer>

--- a/fuse_msgs/package.xml
+++ b/fuse_msgs/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>fuse_msgs</name>
-  <version>1.1.5</version>
+  <version>1.3.0</version>
   <description>
     The fuse_msgs package contains messages capable of holding serialized fuse objects.
   </description>

--- a/fuse_optimizers/package.xml
+++ b/fuse_optimizers/package.xml
@@ -4,7 +4,7 @@
   schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>fuse_optimizers</name>
-  <version>1.1.5</version>
+  <version>1.3.0</version>
   <description>
     The fuse_optimizers package provides a set of optimizer implementations. An optimizer is the object responsible \
     for coordinating the sensors and motion model inputs, computing the optimal state values, and providing access to \

--- a/fuse_publishers/package.xml
+++ b/fuse_publishers/package.xml
@@ -4,7 +4,7 @@
   schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>fuse_publishers</name>
-  <version>1.1.5</version>
+  <version>1.3.0</version>
   <description>
     The fuse_publishers package provides a set of common publisher plugins.
   </description>

--- a/fuse_tutorials/package.xml
+++ b/fuse_tutorials/package.xml
@@ -4,7 +4,7 @@
   schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>fuse_tutorials</name>
-  <version>1.1.5</version>
+  <version>1.3.0</version>
   <description>
     Package containing source code for the fuse tutorials.
   </description>

--- a/fuse_variables/package.xml
+++ b/fuse_variables/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>fuse_variables</name>
-  <version>1.1.5</version>
+  <version>1.3.0</version>
   <description>
     The fuse_variables package provides a set of commonly used variable types, such as 2D and 3D positions, \
     orientations, velocities, and accelerations.

--- a/fuse_viz/package.xml
+++ b/fuse_viz/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>fuse_viz</name>
-  <version>1.1.5</version>
+  <version>1.3.0</version>
   <description>
     The fuse_viz package provides visualization tools for fuse.
   </description>


### PR DESCRIPTION
[written by AI]

## Problem

`jazzy-picknik` inherited upstream jazzy's **1.1.5**. The build farm has already published **`ros-jazzy-fuse 1.2.0-102`** to `s3://picknik-apt` (the ABI-broken build from PickNikRobotics/moveit_pro#20927), and Debian version ordering puts 1.1.5 below it:

```console
$ dpkg --compare-versions "1.1.5-103noble" gt "1.2.0-102noble"; echo $?
1    # false — 1.1.5 sorts lower
```

So a package built from this branch would be *older* than the broken one it replaces. moveit_pro is unaffected — it pins exact versions and `apt-mark hold`s them — but an unpinned `apt install ros-jazzy-fuse` resolves to the broken 1.2.0-102, and that stays "latest" in the repo indefinitely.

## Change

Bump all 13 `package.xml` files 1.1.5 → **1.3.0**. No other version references exist in the tree (checked `*.txt`, `*.py`, `*.cfg`).

1.3.0 rather than 1.2.1: it clears 1.2.0 unambiguously and places the jazzy line ahead of `humble`'s 1.2.0, matching the fact that jazzy is now the forward line. Recommended by @JWhitleyWork.

## Tradeoff

This diverges from upstream jazzy's 1.1.x line, which PickNikRobotics/fuse#36 deliberately preserved. The alternative — staying at 1.1.5 and relying on exact pinning everywhere — was rejected because it leaves a known-broken package as the default resolution for anyone not pinning.

## Follow-on

With the version changed, the build-farm revision should **reset to 0** rather than continue at 103 (`1.3.0-0noble` already outranks `1.2.0-102noble`), per the revision convention in `docs_nonpublic/Modifying-Build-Farm-Dependencies.md`. PickNikRobotics/apt_build_farm#45 is drafted and will be updated to match.

Refs PickNikRobotics/moveit_pro#20927